### PR TITLE
kind of fixed admin rendereing after delete

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -88,20 +88,26 @@ export function Admin() {
 
         //===WIP===
 
-        // let bookingIds = bookings.map(customerId => customerId.customerId)
-        // let i = bookingIds.indexOf(customerId)  
-        // bookings.splice(i, 1)       
-        // setBookings(bookings)
+        let bookingIds = bookings.map(customerId => customerId.customerId)
+        let i = bookingIds.indexOf(customerId)        
+        bookings.splice(i, 1)
 
-        // let customerIds = customers.map(userId => userId._id)
-        // let j = customerIds.indexOf(customerId)
-        // customers.splice(j, 1)     
-        // setCustomers(customers)
+        setBookings(bookings.filter(item => item.customerId !== customerId))
+
+
+        let customerIds = customers.map(userId => userId._id)
+        let j = customerIds.indexOf(customerId)       
+        customers.splice(j, 1)
+        
+        setCustomers(customers.filter(item => item._id !== customerId))
+        
 
         // console.log("i: ", i, "j: ", j)
+        console.log(customerId);
+        
 
-        console.log("delet funk customers", customers);
-        console.log("delet funk bookings", bookings);
+        console.log("delet funk customers", bookings);
+        console.log("delet funk bookings", customers);
     };
 
 
@@ -120,6 +126,8 @@ export function Admin() {
         
         updateBooking(bookingId, changeBooking, customerId);
     };
+
+      
 
     let customer = customers.map((customer: IGetCustomer, j: number) => {
 
@@ -170,6 +178,8 @@ export function Admin() {
             } 
         }
     })
+
+
 
     function printChangeBooking(booking: IGetBooking) {
 

--- a/src/components/Booking/Booking.tsx
+++ b/src/components/Booking/Booking.tsx
@@ -1,10 +1,15 @@
 import { ChangeEvent, useEffect, useState } from "react";
 import { IPostBooking } from "../../models/IPostBooking";
 import { IPostCustomer } from "../../models/IPostCustomer";
+import { Itouched } from "../../models/ITouched";
 import { PostNewBooking } from "../../services/PostNewBooking";
 import { PlusMinusButton } from "../styled-components/Buttons";
 import { BorderDiv, PaddingDiv, WrongInputDiv } from "../styled-components/Divs";
+import { FormInput } from "../styled-components/Forms";
 import { CheckAvailability } from "./CheckAvailability";
+
+
+
 
 export function Booking() {
 
@@ -19,8 +24,8 @@ export function Booking() {
 
     //Används för att kolla om användaren har varit inne i fältet 
     //och ger ett felmedelande först när användaren har lämnat fältet
-    const [touched, setTouched] = useState({
-        name: false,
+    const [touched, setTouched] = useState<Itouched>({
+        fname: false,
         lastname: false,
         email: false,
         phone: false
@@ -207,19 +212,21 @@ export function Booking() {
 
             <form>
                 <label htmlFor="name"> Namn: </label>
-                <input 
+                <FormInput
+                    fname={touched.fname}                    
                     disabled={disableInput} 
                     type="text" 
                     name="name" 
                     onChange={handleChange} 
                     value={customer.name} 
                     id="name"
-                    onBlur={() => setTouched({...touched, name: true})}                 
-                />
+                    onBlur={() => setTouched({...touched, fname: true})}                 
+                /> 
                 <br/>
                 
                 <label htmlFor="lastname"> Efternamn: </label>
-                <input 
+                <FormInput 
+                    lastname={touched.lastname} 
                     disabled={disableInput} 
                     type="text" 
                     name="lastname" 
@@ -231,7 +238,8 @@ export function Booking() {
                 <br/>
 
                 <label htmlFor="email"> E-post: </label>
-                <input 
+                <FormInput
+                    email={touched.email}
                     disabled={disableInput} 
                     type="text" 
                     name="email" 
@@ -243,7 +251,8 @@ export function Booking() {
                 <br/>
 
                 <label htmlFor="phone"> Telefon nr: </label>
-                <input 
+                <FormInput
+                    phone={touched.phone}
                     disabled={disableInput} 
                     type="text" 
                     name="phone" 
@@ -265,7 +274,7 @@ export function Booking() {
             </form>
 
             <WrongInputDiv>
-                {touched.name && <p>{error.nameError.name}</p>}
+                {touched.fname && <p>{error.nameError.name}</p>}
                 {touched.lastname && <p>{error.lastnameError.lastname}</p>}
                 {touched.email && <p>{error.emailError.email}</p>}
                 {touched.phone && <p>{error.phoneError.phone}</p>}

--- a/src/components/styled-components/Forms.tsx
+++ b/src/components/styled-components/Forms.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { Itouched } from "../../models/ITouched";
+
+export const FormInput = styled.input<Itouched>`
+    height: 2rem;
+    border: none;
+    border-radius: 5px;    
+    border-left: 7px solid ${props => props.fname ? "red" : "none"}
+`;

--- a/src/models/ITouched.ts
+++ b/src/models/ITouched.ts
@@ -1,0 +1,6 @@
+export interface Itouched {
+    fname?: boolean,
+    lastname?: boolean,
+    email?: boolean,
+    phone?: boolean
+}


### PR DESCRIPTION
- Admin sidan renderas nu om vid delete.
Ett problem som måste fixas dock är att den tar nu bort alla order med samma kund id (Bara visuellt, de andra order finns fortfarande i APIet och renderas igen när sidan laddas om). Order får samma kund id om samma email används vid olika bokningar. 

-Testade styled-components lite. Ville att rutan som är icke korrekt ifylld ska markeras. Tänkte nog lite fel där, så logiken bör fixas, men det fungerar ..ish för namn rutan. 
Använde touched som villkor, men borde nog använt error.approved.